### PR TITLE
Add Remembered feature

### DIFF
--- a/library/src/main/scala/shiro/sitemap/locs.scala
+++ b/library/src/main/scala/shiro/sitemap/locs.scala
@@ -41,16 +41,16 @@ object Locs {
     () => isRemembered || isAuthenticated,
     () => RedirectBackToReferrer)
   
-  val RequireNoRemembered = If(
+  val RequireNotRemembered = If(
     () => !(isRemembered || isAuthenticated),
     () => RedirectToIndexURL)
   
   def logoutMenu = Menu(Loc("Logout", logoutURL, 
     S.??("logout"), logoutLocParams))
   
-  private val logoutLocParams = RequireAuthentication :: 
+  private val logoutLocParams = RequireRemembered :: 
     EarlyResponse(() => {
-      if(isAuthenticated){ subject.logout() }
+        if(isAuthenticated || isRemembered){ subject.logout() }
       Full(RedirectResponse(Shiro.indexURL.vend))
     }) :: Nil
   

--- a/library/src/main/scala/shiro/utils.scala
+++ b/library/src/main/scala/shiro/utils.scala
@@ -32,8 +32,10 @@ private[shiro] trait Utils {
   def lacksPermission(permission: String) = 
     !hasPermission(permission)
   
-  def hasAnyRoles(roles: Seq[String]) = 
-    test { subject => roles.map(r => subject.hasRole(r.trim)).contains(true) }
+  def hasAnyRoles(roles: Seq[String]) = test { subject =>
+    roles.map(r => subject.hasRole(r.trim)
+      ).contains(true)
+  }
 }
 
 import net.liftweb.common.{Box,Failure,Full}
@@ -48,7 +50,7 @@ trait SubjectLifeCycle {
   
   protected def logout() = subject.logout
   
-  protected def login[T <: AuthenticationToken](token: T) {
+  protected def login[T <: AuthenticationToken](token: T){
     def redirect = S.redirectTo(LoginRedirect.is.openOr("/"))
     if(!isAuthenticated){
       


### PR DESCRIPTION
Add Remembered feature:
1. test isRemembered for shiro.utils
2. locs RequireRemembered and RequireNoRemembered for shiro.sitemap.locs
This features based on subject.isRemembered() Apache Shiro.
RequireRemembered content requires isRemembered or isAuthenticated status for subject.
if request RequireRemembered content is direct for no isRemembered or isAuthenticated subject, then redirect to loginURL page.
RequireNoRemembered content requires no isRemembered and no isAuthenticated status for subject.
if request RequireNoRemembered content is direct for  isRemembered or isAuthenticated subject, then redirect to indexURL page.
