### PR TITLE
Display Error messages on the Login page

### DIFF
--- a/library/src/main/scala/shiro/sitemap/locs.scala
+++ b/library/src/main/scala/shiro/sitemap/locs.scala
@@ -27,7 +27,7 @@ object Locs {
   def RedirectToIndexURL = RedirectResponse(indexURL)
   
   private def DisplayError(message: String) = () => 
-    RedirectWithState(indexURL, RedirectState(() => S.error(message)))
+    RedirectWithState(loginURL, RedirectState(() => S.error(message)))
   
   def RequireAuthentication = If(
     () => isAuthenticated, 


### PR DESCRIPTION
A small change, showing the errors on the Login page instead of the index.

I have my index page secured using HasRole as I am using ldap and not all users are allowed access. The user can be authenticated successfully, but if they are not in the role a redirect loop is caused on the index page as the error message is attempted to be displayed. The login page would be a more appropriate place to show the error message that relates to permissions.
