### PR TITLE
Add scala 2.10.0 as a cross build plus (and some minor changes)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3-2
+sbt.version=0.12.1

--- a/project/build.scala
+++ b/project/build.scala
@@ -11,7 +11,7 @@ object BuildSettings {
     scalaVersion := buildScalaVersion,
     scalaVersion := "2.9.2",
     scalacOptions += "-deprecation",
-    crossScalaVersions := Seq("2.9.1", "2.9.2"),
+    crossScalaVersions := Seq("2.9.1", "2.9.2", "2.10.0"),
     resolvers ++= Seq(
       ScalaToolsReleases,
       "Shiro Releases" at "https://repository.apache.org/content/repositories/releases/",
@@ -64,7 +64,7 @@ object LiftShiroBuild extends Build {
   lazy val library: Project = Project("lift-shiro", file("library"), 
     settings = BuildSettings.buildSettings ++ (
       libraryDependencies ++= Seq(
-        "net.liftweb" %% "lift-webkit" % "2.5-M3" % "compile",
+        "net.liftweb" %% "lift-webkit" % "2.5-M4" % "compile",
         "org.apache.shiro" % "shiro-core" % "1.2.0",
         "org.apache.shiro" % "shiro-web" % "1.2.0",
         "commons-beanutils" % "commons-beanutils" % "20030211.134440"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += "web-plugin.repo" at "http://siasia.github.com/maven2"    
 
-libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % (v+"-0.2.11.1"))
+libraryDependencies <+= sbtVersion(v => "com.github.siasia" %% "xsbt-web-plugin" % ("0.12.0-0.2.11.1"))


### PR DESCRIPTION
```
* Upgraded sbt to 0.12.1 because starting with scala 2.10.0, dependencies do not build for the minor bug fix version.
Meaning, the dependency for lift webkit for scala 2.10 is

net/liftweb/lift-webkit_2.10/2.5-M4/  (note that it is not 2.10.0 ) sbt 0.11.x does not know how to handle this, but sbt 0.12 does

* The web plugin version does not map to sbt version any more, so we are explicit about which one to use
* Added scala 2.10.0 as a cross build version of scala
```
